### PR TITLE
feat: bump PHPUnit to min 6 to have compatible tests with PHP 7.2, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
   - hhvm
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A simple validator to check closure signatures.
 
 ## Requirements
 
-PHP ~5.3
+PHP ~7.0
 
 ## Installation
 
@@ -32,9 +32,11 @@ $validator = new Validator;
 
 $givenSignature = $validator->getSignatureFromClosure($closure);
 
-$wishedSignature = new Signature(array(
-    new Parameter('param1'),
-    new Parameter('param2')
+$wishedSignature = new Signature(
+    [
+        new Parameter('param1'),
+        new Parameter('param2')
+    ]
 );
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     }
   ],
   "require": {
-    "php": ">=5.3"
+    "php": "^7.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "^6.0"
   },
   "autoload": {
     "psr-4": { "Jobcloud\\ClosureValidator\\": "src/" }

--- a/src/Diff.php
+++ b/src/Diff.php
@@ -13,18 +13,18 @@ class Diff implements ToArrayInterface
     /**
      * @var Parameter[]|array
      */
-    protected $missingParameters = array();
+    protected $missingParameters = [];
 
     /**
      * @var Parameter[]|array
      */
-    protected $additionalParameters = array();
+    protected $additionalParameters = [];
 
     /**
      * @param Parameter[]|array $missingParameters
      * @param Parameter[]|array $additionalParameters
      */
-    public function __construct(array $missingParameters = array(), array $additionalParameters = array())
+    public function __construct(array $missingParameters = [], array $additionalParameters = [])
     {
         foreach ($missingParameters as $missingParameter) {
             $this->addMissingParameter($missingParameter);
@@ -40,10 +40,10 @@ class Diff implements ToArrayInterface
      */
     public function toArray()
     {
-        return array(
+        return [
             'missingParameters' => $this->getParametersAsArray($this->missingParameters),
             'additionalParameters' => $this->getParametersAsArray($this->additionalParameters)
-        );
+        ];
     }
 
     /**
@@ -53,7 +53,7 @@ class Diff implements ToArrayInterface
      */
     protected function getParametersAsArray(array $parameters)
     {
-        $parametersAsArray = array();
+        $parametersAsArray = [];
         foreach ($parameters as $parameter) {
             $parametersAsArray[] = $parameter->toArray();
         }

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -35,10 +35,10 @@ class Parameter implements ToArrayInterface
      */
     public function toArray()
     {
-        return array(
+        return [
             'name' => $this->getName(),
             'type' => $this->getType()
-        );
+        ];
     }
 
     /**

--- a/src/Signature.php
+++ b/src/Signature.php
@@ -13,12 +13,12 @@ class Signature implements ToArrayInterface
     /**
      * @var Parameter[]|array
      */
-    protected $parameters = array();
+    protected $parameters = [];
 
     /**
      * @param Parameter[]|array $parameters
      */
-    public function __construct(array $parameters = array())
+    public function __construct(array $parameters = [])
     {
         foreach ($parameters as $parameter) {
             $this->addParameter($parameter);
@@ -30,14 +30,14 @@ class Signature implements ToArrayInterface
      */
     public function toArray()
     {
-        $parameters = array();
+        $parameters = [];
         foreach ($this->parameters as $parameter) {
             $parameters[] = $parameter->toArray();
         }
 
-        return array(
+        return [
             'parameters' => $parameters
-        );
+        ];
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -17,7 +17,7 @@ class Validator
      */
     public function getSignatureFromClosure(\Closure $closure)
     {
-        $parameters = array();
+        $parameters = [];
 
         $reflectionFunction = new \ReflectionFunction($closure);
         foreach ($reflectionFunction->getParameters() as $reflectionParameter) {
@@ -70,7 +70,7 @@ class Validator
      */
     protected function getDifferentParameter(array $parameters1, array $parameters2)
     {
-        $differentParameters = array();
+        $differentParameters = [];
         foreach ($parameters1 as $i => $parameter1) {
             if (!isset($parameters2[$i]) || $parameter1 != $parameters2[$i]) {
                 $differentParameters[] = $parameter1;

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -4,8 +4,9 @@ namespace Jobcloud\Tests\ClosureValidator;
 
 use Jobcloud\ClosureValidator\Diff;
 use Jobcloud\ClosureValidator\Parameter;
+use PHPUnit\Framework\TestCase;
 
-class DiffTest extends \PHPUnit_Framework_TestCase
+class DiffTest extends TestCase
 {
     public function testIdentical()
     {

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -14,10 +14,10 @@ class DiffTest extends TestCase
 
         $this->assertTrue($diff->isIdentical());
         $this->assertEquals(
-            array(
-                'missingParameters' => array(),
-                'additionalParameters' => array()
-            ),
+            [
+                'missingParameters' => [],
+                'additionalParameters' => []
+            ],
             $diff->toArray()
         );
     }
@@ -26,19 +26,19 @@ class DiffTest extends TestCase
     {
         $parameter = new Parameter('parameter');
 
-        $diff = new Diff(array($parameter));
+        $diff = new Diff([$parameter]);
 
         $missingParameters = $diff->getMissingParameters();
 
         $this->assertFalse($diff->isIdentical());
         $this->assertSame($parameter, $missingParameters[0]);
         $this->assertEquals(
-            array(
-                'missingParameters' => array(
+            [
+                'missingParameters' => [
                     $parameter->toArray()
-                ),
-                'additionalParameters' => array()
-            ),
+                ],
+                'additionalParameters' => []
+            ],
             $diff->toArray()
         );
     }
@@ -47,19 +47,19 @@ class DiffTest extends TestCase
     {
         $parameter = new Parameter('parameter');
 
-        $diff = new Diff(array(), array($parameter));
+        $diff = new Diff([], [$parameter]);
 
         $additionalParameters = $diff->getAdditionalParameters();
 
         $this->assertFalse($diff->isIdentical());
         $this->assertSame($parameter, $additionalParameters[0]);
         $this->assertEquals(
-            array(
-                'missingParameters' => array(),
-                'additionalParameters' => array(
+            [
+                'missingParameters' => [],
+                'additionalParameters' => [
                     $parameter->toArray()
-                )
-            ),
+                ]
+            ],
             $diff->toArray()
         );
     }

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -14,10 +14,10 @@ class ParameterTest extends TestCase
         $this->assertEquals('parameter', $parameter->getName());
         $this->assertNull($parameter->getType());
         $this->assertEquals(
-            array(
+            [
                 'name' => 'parameter',
                 'type' => null
-            ),
+            ],
             $parameter->toArray()
         );
     }
@@ -29,10 +29,10 @@ class ParameterTest extends TestCase
         $this->assertEquals('parameter', $parameter->getName());
         $this->assertEquals(Parameter::CLASS_NAME, $parameter->getType());
         $this->assertEquals(
-            array(
+            [
                 'name' => 'parameter',
                 'type' => Parameter::CLASS_NAME
-            ),
+            ],
             $parameter->toArray()
         );
     }

--- a/tests/ParameterTest.php
+++ b/tests/ParameterTest.php
@@ -3,8 +3,9 @@
 namespace Jobcloud\Tests\ClosureValidator;
 
 use Jobcloud\ClosureValidator\Parameter;
+use PHPUnit\Framework\TestCase;
 
-class ParameterTest extends \PHPUnit_Framework_TestCase
+class ParameterTest extends TestCase
 {
     public function testWithoutType()
     {

--- a/tests/SignatureTest.php
+++ b/tests/SignatureTest.php
@@ -4,8 +4,9 @@ namespace Jobcloud\Tests\ClosureValidator;
 
 use Jobcloud\ClosureValidator\Parameter;
 use Jobcloud\ClosureValidator\Signature;
+use PHPUnit\Framework\TestCase;
 
-class SignatureTest extends \PHPUnit_Framework_TestCase
+class SignatureTest extends TestCase
 {
     public function testWithoutParameter()
     {

--- a/tests/SignatureTest.php
+++ b/tests/SignatureTest.php
@@ -13,24 +13,24 @@ class SignatureTest extends TestCase
         $signature = new Signature();
 
         $this->assertCount(0, $signature->getParameters());
-        $this->assertEquals(array('parameters' => array()), $signature->toArray());
+        $this->assertEquals(['parameters' => []], $signature->toArray());
     }
 
     public function testWithParameter()
     {
         $parameter = new Parameter('parameter', Parameter::CLASS_NAME);
-        $signature = new Signature(array($parameter));
+        $signature = new Signature([$parameter]);
 
         $parameters = $signature->getParameters();
 
         $this->assertCount(1, $parameters);
         $this->assertEquals($parameter, $parameters[0]);
         $this->assertEquals(
-            array(
-                'parameters' => array(
+            [
+                'parameters' => [
                     $parameter->toArray()
-                )
-            ),
+                ]
+            ],
             $signature->toArray()
         );
     }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -15,17 +15,17 @@ class ValidatorTest extends TestCase
         $useParameter = 'test';
 
         $closure = function (Parameter $parameter) use ($useParameter) {
-            return array(
+            return [
                 'parameter' => $parameter,
                 'useParameter' => $useParameter
-            );
+            ];
         };
 
         $validator = new Validator();
 
         $signature = $validator->getSignatureFromClosure($closure);
 
-        $this->assertEquals(new Signature(array(new Parameter('parameter', Parameter::CLASS_NAME))), $signature);
+        $this->assertEquals(new Signature([new Parameter('parameter', Parameter::CLASS_NAME)]), $signature);
     }
 
     public function testCompare()
@@ -33,17 +33,17 @@ class ValidatorTest extends TestCase
         $useParameter = 'test';
 
         $closure = function (Parameter $parameter) use ($useParameter) {
-            return array(
+            return [
                 'parameter' => $parameter,
                 'useParameter' => $useParameter
-            );
+            ];
         };
 
         $validator = new Validator();
 
         $givenSignature = $validator->getSignatureFromClosure($closure);
 
-        $wishedSignature = new Signature(array(new Parameter('parameter', Parameter::CLASS_NAME)));
+        $wishedSignature = new Signature([new Parameter('parameter', Parameter::CLASS_NAME)]);
 
         $diff = $validator->compare($givenSignature, $wishedSignature);
 
@@ -56,17 +56,17 @@ class ValidatorTest extends TestCase
         $useParameter = 'test';
 
         $closure = function (Parameter $parameter) use ($useParameter) {
-            return array(
+            return [
                 'parameter' => $parameter,
                 'useParameter' => $useParameter
-            );
+            ];
         };
 
         $validator = new Validator();
 
         $givenSignature = $validator->getSignatureFromClosure($closure);
 
-        $wishedSignature = new Signature(array(new Parameter('parameter1', Parameter::CLASS_NAME)));
+        $wishedSignature = new Signature([new Parameter('parameter1', Parameter::CLASS_NAME)]);
 
         $diff = $validator->compare($givenSignature, $wishedSignature);
 
@@ -88,7 +88,7 @@ class ValidatorTest extends TestCase
 
         $givenSignature = $validator->getSignatureFromClosure($closure);
 
-        $wishedSignature = new Signature(array(new Parameter('parameter', Parameter::CLASS_NAME)));
+        $wishedSignature = new Signature([new Parameter('parameter', Parameter::CLASS_NAME)]);
 
         $diff = $validator->compare($givenSignature, $wishedSignature);
 
@@ -103,19 +103,19 @@ class ValidatorTest extends TestCase
         $useParameter = 'test';
 
         $closure = function (Parameter $parameter1, array $parameter2, $parameter3) use ($useParameter) {
-            return array(
+            return [
                 'parameter1' => $parameter1,
                 'parameter2' => $parameter2,
                 'parameter3' => $parameter3,
                 'useParameter' => $useParameter
-            );
+            ];
         };
 
         $validator = new Validator();
 
         $givenSignature = $validator->getSignatureFromClosure($closure);
 
-        $wishedSignature = new Signature(array(new Parameter('parameter1', Parameter::CLASS_NAME)));
+        $wishedSignature = new Signature([new Parameter('parameter1', Parameter::CLASS_NAME)]);
 
         $diff = $validator->compare($givenSignature, $wishedSignature);
 
@@ -134,17 +134,17 @@ class ValidatorTest extends TestCase
         $useParameter = 'test';
 
         $closure = function (Parameter $parameter) use ($useParameter) {
-            return array(
+            return [
                 'parameter' => $parameter,
                 'useParameter' => $useParameter
-            );
+            ];
         };
 
         $validator = new Validator();
 
         $givenSignature = $validator->getSignatureFromClosure($closure);
 
-        $wishedSignature = new Signature(array(new Parameter('parameter', Parameter::CLASS_NAME)));
+        $wishedSignature = new Signature([new Parameter('parameter', Parameter::CLASS_NAME)]);
 
         $validator->validOrException($givenSignature, $wishedSignature);
     }
@@ -160,17 +160,17 @@ class ValidatorTest extends TestCase
         $useParameter = 'test';
 
         $closure = function (Parameter $parameter) use ($useParameter) {
-            return array(
+            return [
                 'parameter' => $parameter,
                 'useParameter' => $useParameter
-            );
+            ];
         };
 
         $validator = new Validator();
 
         $givenSignature = $validator->getSignatureFromClosure($closure);
 
-        $wishedSignature = new Signature(array(new Parameter('parameter1', Parameter::CLASS_NAME)));
+        $wishedSignature = new Signature([new Parameter('parameter1', Parameter::CLASS_NAME)]);
 
         $validator->validOrException($givenSignature, $wishedSignature);
     }
@@ -186,16 +186,16 @@ class ValidatorTest extends TestCase
         $useParameter = 'test';
 
         $closure = function () use ($useParameter) {
-            return array(
+            return [
                 'useParameter' => $useParameter
-            );
+            ];
         };
 
         $validator = new Validator();
 
         $givenSignature = $validator->getSignatureFromClosure($closure);
 
-        $wishedSignature = new Signature(array(new Parameter('parameter', Parameter::CLASS_NAME)));
+        $wishedSignature = new Signature([new Parameter('parameter', Parameter::CLASS_NAME)]);
 
         $validator->validOrException($givenSignature, $wishedSignature);
     }
@@ -211,19 +211,19 @@ class ValidatorTest extends TestCase
         $useParameter = 'test';
 
         $closure = function (Parameter $parameter1, array $parameter2, $parameter3) use ($useParameter) {
-            return array(
+            return [
                 'parameter1' => $parameter1,
                 'parameter2' => $parameter2,
                 'parameter3' => $parameter3,
                 'useParameter' => $useParameter
-            );
+            ];
         };
 
         $validator = new Validator();
 
         $givenSignature = $validator->getSignatureFromClosure($closure);
 
-        $wishedSignature = new Signature(array(new Parameter('parameter1', Parameter::CLASS_NAME)));
+        $wishedSignature = new Signature([new Parameter('parameter1', Parameter::CLASS_NAME)]);
 
         $validator->validOrException($givenSignature, $wishedSignature);
     }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -6,8 +6,9 @@ use Jobcloud\ClosureValidator\Diff;
 use Jobcloud\ClosureValidator\Parameter;
 use Jobcloud\ClosureValidator\Signature;
 use Jobcloud\ClosureValidator\Validator;
+use PHPUnit\Framework\TestCase;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     public function testGetSignatureFromClosure()
     {
@@ -124,6 +125,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $diff->getAdditionalParameters());
     }
 
+    /**
+     * @return void
+     * @doesNotPerformAssertions
+     */
     public function testValidOrException()
     {
         $useParameter = 'test';


### PR DESCRIPTION
Changelog:
- bump min PHP to 7.0
- bump PHPUnit to 6
- migrate Tests
- mark not asserting test

Needs a new major version of the lib, because of lost support for PHP 5.x.